### PR TITLE
feat(docker-build-image): add config to 

### DIFF
--- a/.github/workflows/docker-build-images.yml
+++ b/.github/workflows/docker-build-images.yml
@@ -93,6 +93,28 @@ on: # yamllint disable-line rule:truthy
         default: "gha"
         type: string
         required: false
+      buildkitd-config-inline:
+        description: |
+          Inline BuildKit daemon configuration.
+          See https://github.com/docker/setup-buildx-action#inputs.
+          Example for insecure registry:
+            [registry."my-registry.local:5000"]
+              http = true
+              insecure = true
+        type: string
+        required: false
+      cache-registry:
+        description: |
+          Optional separate registry for Docker build cache.
+          Use this when cache is stored on a different registry than the final image.
+        type: string
+        required: false
+      cache-registry-username:
+        description: |
+          Username for the cache registry.
+          Required if cache-registry is set and requires authentication.
+        type: string
+        required: false
       sign:
         description: |
           Sign built images.
@@ -115,6 +137,11 @@ on: # yamllint disable-line rule:truthy
         description: |
           GitHub App private key to generate GitHub token to be passed as build secret env.
           See https://github.com/actions/create-github-app-token.
+        required: false
+      cache-registry-password:
+        description: |
+          Password for the cache registry.
+          Required if cache-registry is set and requires authentication.
         required: false
     outputs:
       built-images:
@@ -414,6 +441,10 @@ jobs:
           secret-envs: ${{ steps.prepare-secret-envs.outputs.secret-envs }}
           secrets: ${{ secrets.build-secrets }}
           cache-type: ${{ inputs.cache-type }}
+          cache-registry: ${{ inputs.cache-registry }}
+          cache-registry-username: ${{ inputs.cache-registry-username }}
+          cache-registry-password: ${{ secrets.cache-registry-password }}
+          buildkitd-config-inline: ${{ inputs.buildkitd-config-inline }}
           multi-platform: ${{ matrix.image.multi-platform }}
 
       # FIXME: Set built images infos in file to be uploaded as artifacts, because github action does not handle job outputs for matrix

--- a/actions/docker/build-image/action.yml
+++ b/actions/docker/build-image/action.yml
@@ -178,7 +178,7 @@ runs:
           core.setOutput('cache-image', cacheImage);
 
           try {
-            await exec.exec('command -v docker', { stdio: 'ignore' });
+            await exec.exec('which', ['docker'], { silent: true });
             core.setOutput('docker-exists', 'true');
           } catch (error) {
             // docker not available on runner

--- a/actions/docker/build-image/action.yml
+++ b/actions/docker/build-image/action.yml
@@ -317,7 +317,7 @@ runs:
         username: ${{ inputs.oci-registry-username }}
         password: ${{ inputs.oci-registry-password }}
 
-    - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+    - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
       if: inputs.cache-registry
       with:
         registry: ${{ inputs.cache-registry }}

--- a/actions/docker/build-image/action.yml
+++ b/actions/docker/build-image/action.yml
@@ -87,6 +87,31 @@ inputs:
       See https://docs.docker.com/build/cache/backends.
     default: "gha"
     required: false
+  cache-registry:
+    description: |
+      Optional separate registry for Docker build cache.
+      Use this when cache is stored on a different registry than the final image.
+      If not set, cache operations use the main oci-registry.
+    required: false
+  cache-registry-username:
+    description: |
+      Username for the cache registry.
+      Required if cache-registry is set and requires authentication.
+    required: false
+  cache-registry-password:
+    description: |
+      Password for the cache registry.
+      Required if cache-registry is set and requires authentication.
+    required: false
+  buildkitd-config-inline:
+    description: |
+      Inline BuildKit daemon configuration.
+      See https://github.com/docker/setup-buildx-action#inputs.
+      Example for insecure registry:
+        [registry."my-registry.local:5000"]
+          http = true
+          insecure = true
+    required: false
   multi-platform:
     description: |
       Whether this build participates in a multi-platform image publication.
@@ -174,7 +199,19 @@ runs:
 
           const cacheType = `${{ inputs.cache-type }}`.trim();
           const metadataImage = `${{ steps.metadata.outputs.image }}`;
-          const cacheImage = cacheType === 'registry' ? `${metadataImage}/cache` : metadataImage;
+          const cacheRegistry = `${{ inputs.cache-registry }}`.trim();
+
+          let cacheImage;
+          if (cacheRegistry) {
+            // Use separate cache registry: replace the registry part of the image
+            const imageParts = metadataImage.split('/');
+            // Remove the original registry (first part) and join with cache registry
+            imageParts.shift();
+            cacheImage = `${cacheRegistry}/${imageParts.join('/')}/cache`;
+          } else {
+            // Use main registry for cache
+            cacheImage = cacheType === 'registry' ? `${metadataImage}/cache` : metadataImage;
+          }
           core.setOutput('cache-image', cacheImage);
 
           try {
@@ -248,6 +285,7 @@ runs:
         # FIXME: upgrade version when available (https://hub.docker.com/r/moby/buildkit)
         driver-opts: |
           image=moby/buildkit:v0.27.0
+        buildkitd-config-inline: ${{ inputs.buildkitd-config-inline }}
 
     # Caching setup
     - id: cache-arguments
@@ -278,6 +316,13 @@ runs:
         registry: ${{ inputs.oci-registry }}
         username: ${{ inputs.oci-registry-username }}
         password: ${{ inputs.oci-registry-password }}
+
+    - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      if: inputs.cache-registry
+      with:
+        registry: ${{ inputs.cache-registry }}
+        username: ${{ inputs.cache-registry-username }}
+        password: ${{ inputs.cache-registry-password }}
     # jscpd:ignore-end
 
     - id: build


### PR DESCRIPTION
This pull request introduces enhanced support for Docker build cache management and BuildKit configuration in both the reusable workflow (`.github/workflows/docker-build-images.yml`) and the composite action (`actions/docker/build-image/action.yml`).

The main improvements include:

* The ability to use a separate registry for Docker build cache (with authentication),
* Inline configuration of the BuildKit daemon,
* Improved handling of Docker cache image naming.

---

## Context

We use self-hosted runners to execute our CI jobs and rely on an internal registry to speed up Docker image builds. However, we still use `ghcr.io` as the final registry for storing application images.

These changes are required to allow the internal registry to be used for CI images and BuildKit cache images, while continuing to push the final application images to `ghcr.io`.

To achieve this, BuildKit must be configured to store its cache layers in the internal registry, while still targeting `ghcr.io` for the final images. This requires authenticating against two different Docker registries during the workflow execution.

---

## Docker build cache and registry enhancements

* Added new inputs to both the workflow and the action to allow specifying a separate `cache-registry`, `cache-registry-username`, and `cache-registry-password`. This enables storing Docker build cache in a different registry than the final image, which is useful in multi-registry setups.

* Updated the action logic to build the cache image name using the separate cache registry when provided, ensuring correct image naming for cache operations.

* Added a `docker/login-action` step to authenticate with the cache registry when it is specified, allowing secure access to cache storage.

---

## BuildKit configuration improvements

* Introduced a new `buildkitd-config-inline` input in both the workflow and the action. This allows inline configuration of the BuildKit daemon (for example, to support insecure registries), and passes this configuration directly to the BuildKit setup step.

---

## Fixes

* Replaced `command -v docker` with `which docker` when checking for Docker availability. When executed via `await exec.exec('command -v docker', { stdio: 'ignore' });,` the command did not correctly detect that Docker was already installed on the runner. Switching to `which docker` resolved this issue and allowed Docker to be reliably detected in this execution context.